### PR TITLE
Request note locations

### DIFF
--- a/src/main/java/frc/robot/ros/bridge/FrameRequestPublisher.java
+++ b/src/main/java/frc/robot/ros/bridge/FrameRequestPublisher.java
@@ -1,0 +1,24 @@
+package frc.robot.ros.bridge;
+
+import frc.robot.ros.messages.tj2_interfaces.RequestFrames;
+import frc.team88.ros.bridge.BridgePublisher;
+import frc.team88.ros.bridge.ROSNetworkTablesBridge;
+import frc.team88.ros.messages.DurationPrimitive;
+
+public class FrameRequestPublisher implements Publisher {
+    private final BridgePublisher<RequestFrames> requestPub;
+    private double requestDuration = 0.0;
+
+    public FrameRequestPublisher(ROSNetworkTablesBridge bridge, double requestDuration) {
+        requestPub = new BridgePublisher<>(bridge, "request_frames");
+        this.requestDuration = requestDuration;
+    }
+
+    public void setRequestDuration(double requestDuration) {
+        this.requestDuration = requestDuration;
+    }
+
+    public void publish() {
+        requestPub.send(new RequestFrames(requestPub.getHeader(""), new DurationPrimitive(requestDuration), 0));
+    }
+}

--- a/src/main/java/frc/robot/ros/bridge/GameObjectsSubscriber.java
+++ b/src/main/java/frc/robot/ros/bridge/GameObjectsSubscriber.java
@@ -1,0 +1,30 @@
+package frc.robot.ros.bridge;
+
+import java.util.Optional;
+
+import frc.robot.ros.messages.tj2_interfaces.GameObjectsStamped;
+import frc.team88.ros.bridge.BridgeSubscriber;
+import frc.team88.ros.bridge.ROSNetworkTablesBridge;
+
+public class GameObjectsSubscriber implements Subscriber<GameObjectsStamped> {
+    private final BridgeSubscriber<GameObjectsStamped> objectsSub;
+    private GameObjectsStamped lastObjects = new GameObjectsStamped();
+
+    public GameObjectsSubscriber(ROSNetworkTablesBridge bridge) {
+        objectsSub = new BridgeSubscriber<>(bridge, "detections", GameObjectsStamped.class);
+    }
+
+    public Optional<GameObjectsStamped> receive() {
+        Optional<GameObjectsStamped> optMsg;
+        if ((optMsg = objectsSub.receive()).isPresent()) {
+            lastObjects = optMsg.get();
+            return optMsg;
+        }
+        return optMsg;
+    }
+
+    public GameObjectsStamped getLastObjects() {
+        receive();
+        return lastObjects;
+    }
+}

--- a/src/main/java/frc/robot/ros/bridge/TagSubscriber.java
+++ b/src/main/java/frc/robot/ros/bridge/TagSubscriber.java
@@ -2,7 +2,7 @@ package frc.robot.ros.bridge;
 
 import java.util.Optional;
 
-import frc.robot.ros.bridge.AprilTagDetectionArray;
+import frc.robot.ros.messages.apriltag_ros.AprilTagDetectionArray;
 import frc.team88.ros.bridge.BridgeSubscriber;
 import frc.team88.ros.bridge.ROSNetworkTablesBridge;
 

--- a/src/main/java/frc/robot/ros/messages/apriltag_ros/AprilTagDetection.java
+++ b/src/main/java/frc/robot/ros/messages/apriltag_ros/AprilTagDetection.java
@@ -1,5 +1,5 @@
 // Auto generated!! Do not modify.
-package frc.robot.ros.bridge;
+package frc.robot.ros.messages.apriltag_ros;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;

--- a/src/main/java/frc/robot/ros/messages/apriltag_ros/AprilTagDetectionArray.java
+++ b/src/main/java/frc/robot/ros/messages/apriltag_ros/AprilTagDetectionArray.java
@@ -1,5 +1,5 @@
 // Auto generated!! Do not modify.
-package frc.robot.ros.bridge;
+package frc.robot.ros.messages.apriltag_ros;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -10,7 +10,7 @@ import java.util.Arrays;
 public class AprilTagDetectionArray extends frc.team88.ros.messages.RosMessage {
 
     private frc.team88.ros.messages.std_msgs.RosHeader header = new frc.team88.ros.messages.std_msgs.RosHeader();
-    private ArrayList<frc.robot.ros.bridge.AprilTagDetection> detections = new ArrayList<>();
+    private ArrayList<frc.robot.ros.messages.apriltag_ros.AprilTagDetection> detections = new ArrayList<>();
 
     @Expose(serialize = false, deserialize = false)
     public final java.lang.String _type = "apriltag_ros/AprilTagDetectionArray";
@@ -20,7 +20,7 @@ public class AprilTagDetectionArray extends frc.team88.ros.messages.RosMessage {
     }
 
     public AprilTagDetectionArray(frc.team88.ros.messages.std_msgs.RosHeader header,
-            frc.robot.ros.bridge.AprilTagDetection[] detections) {
+            frc.robot.ros.messages.apriltag_ros.AprilTagDetection[] detections) {
         this.header = header;
         this.detections = new ArrayList<>(Arrays.asList(detections));
     }
@@ -29,7 +29,7 @@ public class AprilTagDetectionArray extends frc.team88.ros.messages.RosMessage {
         this.header = new frc.team88.ros.messages.std_msgs.RosHeader(jsonObj.get("header").getAsJsonObject());
         for (JsonElement detections_element : jsonObj.getAsJsonArray("detections")) {
             this.detections.add(
-                    new frc.robot.ros.bridge.AprilTagDetection(detections_element.getAsJsonObject()));
+                    new frc.robot.ros.messages.apriltag_ros.AprilTagDetection(detections_element.getAsJsonObject()));
         }
     }
 
@@ -37,7 +37,7 @@ public class AprilTagDetectionArray extends frc.team88.ros.messages.RosMessage {
         return this.header;
     }
 
-    public ArrayList<frc.robot.ros.bridge.AprilTagDetection> getDetections() {
+    public ArrayList<frc.robot.ros.messages.apriltag_ros.AprilTagDetection> getDetections() {
         return this.detections;
     }
 
@@ -45,7 +45,7 @@ public class AprilTagDetectionArray extends frc.team88.ros.messages.RosMessage {
         this.header = header;
     }
 
-    public void setDetections(ArrayList<frc.robot.ros.bridge.AprilTagDetection> detections) {
+    public void setDetections(ArrayList<frc.robot.ros.messages.apriltag_ros.AprilTagDetection> detections) {
         this.detections = detections;
     }
 

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/GameObject.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/GameObject.java
@@ -1,0 +1,95 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+public class GameObject extends frc.team88.ros.messages.RosMessage {
+
+    private java.lang.String label = "";
+    private int object_index = 0;
+    private short class_index = 0;
+    private float confidence = 0.0f;
+    private frc.team88.ros.messages.geometry_msgs.Pose pose = new frc.team88.ros.messages.geometry_msgs.Pose();
+    private frc.robot.ros.messages.tj2_interfaces.UVBoundingBox bounding_box_2d = new frc.robot.ros.messages.tj2_interfaces.UVBoundingBox();
+    private frc.robot.ros.messages.tj2_interfaces.XYZBoundingBox bounding_box_3d = new frc.robot.ros.messages.tj2_interfaces.XYZBoundingBox();
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/GameObject";
+
+    public GameObject() {
+
+    }
+
+    public GameObject(java.lang.String label, int object_index, short class_index, float confidence, frc.team88.ros.messages.geometry_msgs.Pose pose, frc.robot.ros.messages.tj2_interfaces.UVBoundingBox bounding_box_2d, frc.robot.ros.messages.tj2_interfaces.XYZBoundingBox bounding_box_3d) {
+        this.label = label;
+        this.object_index = object_index;
+        this.class_index = class_index;
+        this.confidence = confidence;
+        this.pose = pose;
+        this.bounding_box_2d = bounding_box_2d;
+        this.bounding_box_3d = bounding_box_3d;
+    }
+
+    public GameObject(JsonObject jsonObj) {
+        this.label = jsonObj.get("label").getAsString();
+        this.object_index = jsonObj.get("object_index").getAsInt();
+        this.class_index = jsonObj.get("class_index").getAsShort();
+        this.confidence = jsonObj.get("confidence").getAsFloat();
+        this.pose = new frc.team88.ros.messages.geometry_msgs.Pose(jsonObj.get("pose").getAsJsonObject());
+        this.bounding_box_2d = new frc.robot.ros.messages.tj2_interfaces.UVBoundingBox(jsonObj.get("bounding_box_2d").getAsJsonObject());
+        this.bounding_box_3d = new frc.robot.ros.messages.tj2_interfaces.XYZBoundingBox(jsonObj.get("bounding_box_3d").getAsJsonObject());
+    }
+
+    public java.lang.String getLabel() {
+        return this.label;
+    }
+    public int getObjectIndex() {
+        return this.object_index;
+    }
+    public short getClassIndex() {
+        return this.class_index;
+    }
+    public float getConfidence() {
+        return this.confidence;
+    }
+    public frc.team88.ros.messages.geometry_msgs.Pose getPose() {
+        return this.pose;
+    }
+    public frc.robot.ros.messages.tj2_interfaces.UVBoundingBox getBoundingBox2D() {
+        return this.bounding_box_2d;
+    }
+    public frc.robot.ros.messages.tj2_interfaces.XYZBoundingBox getBoundingBox3D() {
+        return this.bounding_box_3d;
+    }
+
+    public void setLabel(java.lang.String label) {
+        this.label = label;
+    }
+    public void setObjectIndex(int object_index) {
+        this.object_index = object_index;
+    }
+    public void setClassIndex(short class_index) {
+        this.class_index = class_index;
+    }
+    public void setConfidence(float confidence) {
+        this.confidence = confidence;
+    }
+    public void setPose(frc.team88.ros.messages.geometry_msgs.Pose pose) {
+        this.pose = pose;
+    }
+    public void setBoundingBox2D(frc.robot.ros.messages.tj2_interfaces.UVBoundingBox bounding_box_2d) {
+        this.bounding_box_2d = bounding_box_2d;
+    }
+    public void setBoundingBox3D(frc.robot.ros.messages.tj2_interfaces.XYZBoundingBox bounding_box_3d) {
+        this.bounding_box_3d = bounding_box_3d;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/GameObjectsStamped.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/GameObjectsStamped.java
@@ -1,0 +1,73 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class GameObjectsStamped extends frc.team88.ros.messages.RosMessage {
+
+    private frc.team88.ros.messages.std_msgs.RosHeader header = new frc.team88.ros.messages.std_msgs.RosHeader();
+    private ArrayList<frc.robot.ros.messages.tj2_interfaces.GameObject> objects = new ArrayList<>();
+    private int width = 0;
+    private int height = 0;
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/GameObjectsStamped";
+
+    public GameObjectsStamped() {
+
+    }
+
+    public GameObjectsStamped(frc.team88.ros.messages.std_msgs.RosHeader header, frc.robot.ros.messages.tj2_interfaces.GameObject[] objects, int width, int height) {
+        this.header = header;
+        this.objects = new ArrayList<>(Arrays.asList(objects));
+        this.width = width;
+        this.height = height;
+    }
+
+    public GameObjectsStamped(JsonObject jsonObj) {
+        this.header = new frc.team88.ros.messages.std_msgs.RosHeader(jsonObj.get("header").getAsJsonObject());
+        for (JsonElement objects_element : jsonObj.getAsJsonArray("objects")) {
+            this.objects.add(new frc.robot.ros.messages.tj2_interfaces.GameObject(objects_element.getAsJsonObject()));
+        }
+        this.width = jsonObj.get("width").getAsInt();
+        this.height = jsonObj.get("height").getAsInt();
+    }
+
+    public frc.team88.ros.messages.std_msgs.RosHeader getHeader() {
+        return this.header;
+    }
+    public ArrayList<frc.robot.ros.messages.tj2_interfaces.GameObject> getObjects() {
+        return this.objects;
+    }
+    public int getWidth() {
+        return this.width;
+    }
+    public int getHeight() {
+        return this.height;
+    }
+
+    public void setHeader(frc.team88.ros.messages.std_msgs.RosHeader header) {
+        this.header = header;
+    }
+    public void setObjects(ArrayList<frc.robot.ros.messages.tj2_interfaces.GameObject> objects) {
+        this.objects = objects;
+    }
+    public void setWidth(int width) {
+        this.width = width;
+    }
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/RequestFrames.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/RequestFrames.java
@@ -1,0 +1,59 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+public class RequestFrames extends frc.team88.ros.messages.RosMessage {
+
+    private frc.team88.ros.messages.std_msgs.RosHeader header = new frc.team88.ros.messages.std_msgs.RosHeader();
+    private frc.team88.ros.messages.DurationPrimitive request_duration = new frc.team88.ros.messages.DurationPrimitive();
+    private int num_frames = 0;
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/RequestFrames";
+
+    public RequestFrames() {
+
+    }
+
+    public RequestFrames(frc.team88.ros.messages.std_msgs.RosHeader header, frc.team88.ros.messages.DurationPrimitive request_duration, int num_frames) {
+        this.header = header;
+        this.request_duration = request_duration;
+        this.num_frames = num_frames;
+    }
+
+    public RequestFrames(JsonObject jsonObj) {
+        this.header = new frc.team88.ros.messages.std_msgs.RosHeader(jsonObj.get("header").getAsJsonObject());
+        this.request_duration = new frc.team88.ros.messages.DurationPrimitive(jsonObj.get("request_duration").getAsJsonObject());
+        this.num_frames = jsonObj.get("num_frames").getAsInt();
+    }
+
+    public frc.team88.ros.messages.std_msgs.RosHeader getHeader() {
+        return this.header;
+    }
+    public frc.team88.ros.messages.DurationPrimitive getRequestDuration() {
+        return this.request_duration;
+    }
+    public int getNumFrames() {
+        return this.num_frames;
+    }
+
+    public void setHeader(frc.team88.ros.messages.std_msgs.RosHeader header) {
+        this.header = header;
+    }
+    public void setRequestDuration(frc.team88.ros.messages.DurationPrimitive request_duration) {
+        this.request_duration = request_duration;
+    }
+    public void setNumFrames(int num_frames) {
+        this.num_frames = num_frames;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/UVBoundingBox.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/UVBoundingBox.java
@@ -1,0 +1,70 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+public class UVBoundingBox extends frc.team88.ros.messages.RosMessage {
+
+    private frc.robot.ros.messages.tj2_interfaces.UVKeypoint[] points = new frc.robot.ros.messages.tj2_interfaces.UVKeypoint[] {
+        new frc.robot.ros.messages.tj2_interfaces.UVKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.UVKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.UVKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.UVKeypoint()
+    };
+    private int width = 0;
+    private int height = 0;
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/UVBoundingBox";
+
+    public UVBoundingBox() {
+
+    }
+
+    public UVBoundingBox(frc.robot.ros.messages.tj2_interfaces.UVKeypoint[] points, int width, int height) {
+        for (int index = 0; index < 4; index++) {
+            this.points[index] = points[index];
+        }
+        this.width = width;
+        this.height = height;
+    }
+
+    public UVBoundingBox(JsonObject jsonObj) {
+        int points_element_index = 0;
+        for (JsonElement points_element : jsonObj.getAsJsonArray("points")) {
+            this.points[points_element_index++] = new frc.robot.ros.messages.tj2_interfaces.UVKeypoint(points_element.getAsJsonObject());
+        }
+        this.width = jsonObj.get("width").getAsInt();
+        this.height = jsonObj.get("height").getAsInt();
+    }
+
+    public frc.robot.ros.messages.tj2_interfaces.UVKeypoint[] getPoints() {
+        return this.points;
+    }
+    public int getWidth() {
+        return this.width;
+    }
+    public int getHeight() {
+        return this.height;
+    }
+
+    public void setPoints(frc.robot.ros.messages.tj2_interfaces.UVKeypoint[] points) {
+        this.points = points;
+    }
+    public void setWidth(int width) {
+        this.width = width;
+    }
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/UVKeypoint.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/UVKeypoint.java
@@ -1,0 +1,50 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+public class UVKeypoint extends frc.team88.ros.messages.RosMessage {
+
+    private int x = 0;
+    private int y = 0;
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/UVKeypoint";
+
+    public UVKeypoint() {
+
+    }
+
+    public UVKeypoint(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public UVKeypoint(JsonObject jsonObj) {
+        this.x = jsonObj.get("x").getAsInt();
+        this.y = jsonObj.get("y").getAsInt();
+    }
+
+    public int getX() {
+        return this.x;
+    }
+    public int getY() {
+        return this.y;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/XYZBoundingBox.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/XYZBoundingBox.java
@@ -1,0 +1,65 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+public class XYZBoundingBox extends frc.team88.ros.messages.RosMessage {
+
+    private frc.robot.ros.messages.tj2_interfaces.XYZKeypoint[] points = new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint[] {
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(),
+        new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint()
+    };
+    private frc.team88.ros.messages.geometry_msgs.Vector3 dimensions = new frc.team88.ros.messages.geometry_msgs.Vector3();
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/XYZBoundingBox";
+
+    public XYZBoundingBox() {
+
+    }
+
+    public XYZBoundingBox(frc.robot.ros.messages.tj2_interfaces.XYZKeypoint[] points, frc.team88.ros.messages.geometry_msgs.Vector3 dimensions) {
+        for (int index = 0; index < 8; index++) {
+            this.points[index] = points[index];
+        }
+        this.dimensions = dimensions;
+    }
+
+    public XYZBoundingBox(JsonObject jsonObj) {
+        int points_element_index = 0;
+        for (JsonElement points_element : jsonObj.getAsJsonArray("points")) {
+            this.points[points_element_index++] = new frc.robot.ros.messages.tj2_interfaces.XYZKeypoint(points_element.getAsJsonObject());
+        }
+        this.dimensions = new frc.team88.ros.messages.geometry_msgs.Vector3(jsonObj.get("dimensions").getAsJsonObject());
+    }
+
+    public frc.robot.ros.messages.tj2_interfaces.XYZKeypoint[] getPoints() {
+        return this.points;
+    }
+    public frc.team88.ros.messages.geometry_msgs.Vector3 getDimensions() {
+        return this.dimensions;
+    }
+
+    public void setPoints(frc.robot.ros.messages.tj2_interfaces.XYZKeypoint[] points) {
+        this.points = points;
+    }
+    public void setDimensions(frc.team88.ros.messages.geometry_msgs.Vector3 dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}

--- a/src/main/java/frc/robot/ros/messages/tj2_interfaces/XYZKeypoint.java
+++ b/src/main/java/frc/robot/ros/messages/tj2_interfaces/XYZKeypoint.java
@@ -1,0 +1,59 @@
+// Auto generated!! Do not modify.
+package frc.robot.ros.messages.tj2_interfaces;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+
+public class XYZKeypoint extends frc.team88.ros.messages.RosMessage {
+
+    private float x = 0.0f;
+    private float y = 0.0f;
+    private float z = 0.0f;
+
+    @Expose(serialize = false, deserialize = false)
+    public final java.lang.String _type = "tj2_interfaces/XYZKeypoint";
+
+    public XYZKeypoint() {
+
+    }
+
+    public XYZKeypoint(float x, float y, float z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public XYZKeypoint(JsonObject jsonObj) {
+        this.x = jsonObj.get("x").getAsFloat();
+        this.y = jsonObj.get("y").getAsFloat();
+        this.z = jsonObj.get("z").getAsFloat();
+    }
+
+    public float getX() {
+        return this.x;
+    }
+    public float getY() {
+        return this.y;
+    }
+    public float getZ() {
+        return this.z;
+    }
+
+    public void setX(float x) {
+        this.x = x;
+    }
+    public void setY(float y) {
+        this.y = y;
+    }
+    public void setZ(float z) {
+        this.z = z;
+    }
+
+    public JsonObject toJSON() {
+        return ginst.toJsonTree(this).getAsJsonObject();
+    }
+
+    public java.lang.String toString() {
+        return ginst.toJson(this);
+    }
+}


### PR DESCRIPTION
Adds interfaces for frame request topics. This allows the Jetson to temporarily switch over to searching for notes for a set duration.

FrameRequestPublisher publishes a duration request which indicates to ROS that the apriltag cameras should be paused and the ZED camera should be enabled. When the ZED publishes images, they can piped through the neural net. This outputs GameObjectsStamped.

GameObjectsSubscriber listens for this message. This subscriber holds the last message received.
